### PR TITLE
Allow systems to provide a default deadline specified by DEADLINE.

### DIFF
--- a/src/shoobx/wfmc/process.py
+++ b/src/shoobx/wfmc/process.py
@@ -321,7 +321,7 @@ class Activity(persistent.Persistent):
         self.createWorkItems()
 
     def digestDeadlineDefinition(self, process, definition,
-                                 deadlineDef):
+                                 deadlineDef, defaultDeadline=None):
         evaluator = interfaces.IPythonExpressionEvaluator(self.process)
         if not deadlineDef.duration:
             log.warning(
@@ -331,7 +331,8 @@ class Activity(persistent.Persistent):
         try:
             evaled = evaluator.evaluate(deadlineDef.duration,
                                         {'timedelta': timedelta,
-                                         'datetime': datetime})
+                                         'datetime': datetime,
+                                         'DEADLINE': defaultDeadline})
         except Exception as e:
             raise RuntimeError(
                 'Evaluating the deadline duration failed '


### PR DESCRIPTION
This change allows users to specify a default deadline that can be specified in activity definitions as 'DEADLINE' when provided.  The system is responsible for providing the appropriate value for the default deadline, default is None which will cause deadline parsing to fail (by design) if no default deadline is provided by the system and DEADLINE is specified in the activity definition.