### PR TITLE
Support for LiteralParameters

### DIFF
--- a/src/shoobx/wfmc/interfaces.py
+++ b/src/shoobx/wfmc/interfaces.py
@@ -378,7 +378,10 @@ class IParameterDefinition(interface.Interface):
 
     input = interface.Attribute("Is this an input parameter?")
 
+    skipInputEval = interface.Attribute("Should we skip evaluating the input parameter?")
+
     output = interface.Attribute("Is this an output parameter?")
+
 
 
 class IPoolDefinition(interface.Interface):

--- a/src/shoobx/wfmc/process.py
+++ b/src/shoobx/wfmc/process.py
@@ -919,12 +919,17 @@ def evaluateInputs(
             if expr == '':
                 expr = getattr(parameter, 'initialValue', '')
             __traceback_info__ = (parameter, expr)
-            try:
-                value = evaluator.evaluate(expr)
-            except interfaces.EvaluateException:
-                if strict:
-                    raise
-                continue
+
+            if not parameter.skipInputEval:
+                try:
+                    value = evaluator.evaluate(expr)
+                except interfaces.EvaluateException:
+                    if strict:
+                        raise
+                    continue
+            else:
+                value = expr
+
             args.append((parameter.__name__, value))
 
     return args
@@ -1156,7 +1161,7 @@ class ActivityStarted:
 @interface.implementer(interfaces.IParameterDefinition)
 class Parameter(object):
 
-    input = output = False
+    input = output = skipInputEval = False
     initialValue = None
 
     def __init__(self, name):
@@ -1172,6 +1177,9 @@ class OutputParameter(Parameter):
 
 class InputParameter(Parameter):
     input = True
+
+class LiteralInputParameter(InputParameter):
+    skipInputEval = True
 
 class InputOutputParameter(InputParameter, OutputParameter):
 

--- a/src/shoobx/wfmc/process.py
+++ b/src/shoobx/wfmc/process.py
@@ -441,7 +441,7 @@ class Activity(persistent.Persistent):
 
         # Instantiate Subflows
         for subflow, execution, actual in self.definition.subflows:
-            # Figre out formal parameters. At this point, process definition
+            # Figure out formal parameters. At this point, process definition
             # has to be available.
             subflow_pd = self.process.getSubflowProcessDefinition(subflow)
             formal = subflow_pd.parameters
@@ -479,7 +479,7 @@ class Activity(persistent.Persistent):
                 __traceback_info__ = (
                     workitem, self.activity_definition_identifier)
 
-                inputs = evaluateInputs(self.process, formal, actual, evaluator)
+                inputs = evaluateInputs(workitem, formal, actual, evaluator)
                 args = {n: a for n, a in inputs}
 
                 __traceback_info__ = (self.activity_definition_identifier,
@@ -903,17 +903,18 @@ def getEvaluator(process):
 
 
 def evaluateInputs(
-    process,
-    formal,
+    workitem,
+    defaultFormal,
     actual,
     evaluator,
     strict=True,
 ):
-    """Evaluate input parameters for the process or activity.
+    """Evaluate input parameters for the workitem.
 
     Return list of pairs: (name, value) for each input parameter.
     """
     args = []
+    formal = getattr(workitem, 'parameters', None) or defaultFormal
     for parameter, expr in zip(formal, actual):
         if parameter.input:
             if expr == '':

--- a/src/shoobx/wfmc/tests.py
+++ b/src/shoobx/wfmc/tests.py
@@ -134,7 +134,7 @@ def test_literal_input_parameters():
     has a single activity that just outputs them.
 
     The first variable will be a normal Input variable, the second
-    will be a literal input variable
+    will be a literal input variable defined by the workitem
 
     The first variable will return the actual value, the second
     will be the literal value "y", representing the expression definition
@@ -149,7 +149,7 @@ def test_literal_input_parameters():
 
     >>> pd.defineParameters(
     ...     process.InputParameter('x'),
-    ...     process.LiteralInputParameter('y'),
+    ...     process.InputParameter('y'),
     ...     )
 
     >>> pd.defineActivities(
@@ -162,7 +162,7 @@ def test_literal_input_parameters():
     >>> pd.defineApplications(
     ...     eek = process.Application(
     ...         process.InputParameter('x'),
-    ...         process.LiteralInputParameter('y'),
+    ...         process.InputParameter('y'),
     ...         )
     ...     )
 
@@ -188,6 +188,7 @@ def test_literal_input_parameters():
     ... class Eek:
     ...     component.adapts(interfaces.IParticipant)
     ...
+    ...     parameters=(process.InputParameter('x'), process.LiteralInputParameter('y'))
     ...     def __init__(self, participant, process, activity):
     ...         self.participant = participant
     ...

--- a/src/shoobx/wfmc/xpdl.py
+++ b/src/shoobx/wfmc/xpdl.py
@@ -217,7 +217,6 @@ class XPDLHandler(xml.sax.handler.ContentHandler):
 
     parameter_types = {
         'IN': shoobx.wfmc.process.InputParameter,
-        'LITERALIN': shoobx.wfmc.process.LiteralInputParameter,
         'OUT': shoobx.wfmc.process.OutputParameter,
         'INOUT': shoobx.wfmc.process.InputOutputParameter,
         }

--- a/src/shoobx/wfmc/xpdl.py
+++ b/src/shoobx/wfmc/xpdl.py
@@ -217,6 +217,7 @@ class XPDLHandler(xml.sax.handler.ContentHandler):
 
     parameter_types = {
         'IN': shoobx.wfmc.process.InputParameter,
+        'LITERALIN': shoobx.wfmc.process.LiteralInputParameter,
         'OUT': shoobx.wfmc.process.OutputParameter,
         'INOUT': shoobx.wfmc.process.InputOutputParameter,
         }


### PR DESCRIPTION
Skips the eval() step of parameters. Allows for passing in code into the paramter that is meant to be eval()'d seperately by the workitem